### PR TITLE
Small fixes and reformatting of some files

### DIFF
--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/client.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/client.py
@@ -34,16 +34,16 @@ class NetAppNotReady(Exception):
     """
 
 
-class NetAppClient():
+class NetAppClient:
     """
     Basic implementation of the NetApp client. It creates the Requests 
     object with session and bind callbacks for connection info 
     and results from the NetApp.
     """
 
-    def __init__(self, host: str, user_id: str, password: str, task_id: str, resource_lock: str,
-                 results_event: Callable, use_middleware=True, wait_for_netapp=True, netapp_uri: str = None,
-                 netapp_port: int = None) -> None:
+    def __init__(self, host: str, user_id: str, password: str, task_id: str, resource_lock: bool,
+                 results_event: Callable, use_middleware: bool = True, wait_for_netapp: bool = True,
+                 netapp_uri: str = None, netapp_port: int = None) -> None:
         """Constructor
 
         Args:
@@ -51,11 +51,12 @@ class NetAppClient():
             user_id (str): The middleware user's id
             password (str): The middleware user's password
             task_id (str): The ID of the NetApp to be deployed
-            resource_lock (str): TBA
+            resource_lock (bool): TBA
             results_event (Callable): callback where results will arrive
             use_middleware (bool, optional): Defines if the NetApp should be deployed by middleware. 
                 If False, the netapp_uri and netapp_port need to be defined, otherwise, 
                 they need to be left None. Defaults to True.
+            wait_for_netapp (bool, optional):
             netapp_uri (str, optional): The URI of the NetApp interface. Defaults to None.
             netapp_port (int, optional): The port of the NetApp interface. Defaults to None.
         
@@ -258,7 +259,8 @@ class NetAppClient():
             response = requests.post(self.build_middleware_api_endpoint("Task/Plan"), json=data, headers=hed).json()
             if "statusCode" in response and (response["statusCode"] == 500 or response["statusCode"] == 400):
                 raise FailedToConnect(f"response {response['statusCode']}: {response['message']}")
-
+            # todo:             if "errors" in response:
+            #                 raise FailedToConnect(str(response["errors"]))
             action_sequence = response['ActionSequence']
             # print(action_sequence)
             self.action_plan_id = response['ActionPlanId']

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/client_gstreamer.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/client_gstreamer.py
@@ -11,16 +11,26 @@ class NetAppClientGstreamer(NetAppClient):
         NetAppClient (_type_): the base client
     """
 
-    def __init__(self, host: str, user_id: str, password: str, task_id: str, resource_lock: str,
-                 results_event: Callable, use_middleware=True, wait_for_netapp=True, netapp_uri: str = None,
-                 netapp_port: int = None) -> None:
+    def __init__(self, host: str, user_id: str, password: str, task_id: str, resource_lock: bool,
+                 results_event: Callable, use_middleware: bool = True, wait_for_netapp: bool = True,
+                 netapp_uri: str = None, netapp_port: int = None) -> None:
         """
         Constructor
 
         Args:
-            host (str): IP address or hostname of the NetApp interface
-            port (int): port of the NetApp interface
+            host (str): The IP or hostname of the middleware
+            user_id (str): The middleware user's id
+            password (str): The middleware user's password
+            task_id (str): The ID of the NetApp to be deployed
+            resource_lock (bool): TBA
             results_event (Callable): callback where results will arrive
+            use_middleware (bool, optional): Defines if the NetApp should be deployed by middleware.
+                If False, the netapp_uri and netapp_port need to be defined, otherwise,
+                they need to be left None. Defaults to True.
+            wait_for_netapp (bool, optional):
+            netapp_uri (str, optional): The URI of the NetApp interface. Defaults to None.
+            netapp_port (int, optional): The port of the NetApp interface. Defaults to None.
+
         """
         super().__init__(host, user_id, password, task_id, resource_lock, results_event, use_middleware,
                          wait_for_netapp, netapp_uri, netapp_port)
@@ -30,12 +40,12 @@ class NetAppClientGstreamer(NetAppClient):
 
     def register(self, args=None) -> str:
         """
-        Calls the /register endpoint of the NetApp interface and if the 
+        Calls the /register endpoint of the NetApp interface and if the
         registration is successful, it sets up the websocket connection
         for results retrieval. Besides, it obtains the gstreamer port.
 
         Args:
-            args (_type_, optional): optional parameters to be passed to 
+            args (_type_, optional): optional parameters to be passed to
                 the NetApp, in the form of dict. Defaults to None.
 
         Raises:

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/client_gstreamer.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/client_gstreamer.py
@@ -2,6 +2,7 @@ from typing import Callable
 from .client import NetAppClient
 from .client import FailedToConnect
 
+
 class NetAppClientGstreamer(NetAppClient):
     """
     NetApp client which asks the NetApp for h264 stream setup.
@@ -10,8 +11,9 @@ class NetAppClientGstreamer(NetAppClient):
         NetAppClient (_type_): the base client
     """
 
-    def __init__(self, host: str, user_id: str, password: str, task_id: str, resource_lock: str, results_event: Callable, use_middleware=True, wait_for_netapp=True, netapp_uri: str = None, netapp_port: int = None) -> None:
-        super().__init__(host, user_id, password, task_id, resource_lock, results_event, use_middleware, wait_for_netapp, netapp_uri, netapp_port)
+    def __init__(self, host: str, user_id: str, password: str, task_id: str, resource_lock: str,
+                 results_event: Callable, use_middleware=True, wait_for_netapp=True, netapp_uri: str = None,
+                 netapp_port: int = None) -> None:
         """
         Constructor
 
@@ -20,29 +22,30 @@ class NetAppClientGstreamer(NetAppClient):
             port (int): port of the NetApp interface
             results_event (Callable): callback where results will arrive
         """
+        super().__init__(host, user_id, password, task_id, resource_lock, results_event, use_middleware,
+                         wait_for_netapp, netapp_uri, netapp_port)
         # TODO: update args
         # holds the gstreamer port
         self.gstreamer_port = None
 
-
     def register(self, args=None) -> str:
         """
         Calls the /register endpoint of the NetApp interface and if the 
-        registration is successfull, it setups the websocket connection
+        registration is successful, it sets up the websocket connection
         for results retrieval. Besides, it obtains the gstreamer port.
 
         Args:
             args (_type_, optional): optional parameters to be passed to 
-            the NetApp, in the form of dict. Defaults to None.
+                the NetApp, in the form of dict. Defaults to None.
 
         Raises:
             FailedToConnect: raised when connection failed or the server
-                responsed with wrong data
+                responded with wrong data
 
         Returns:
             str: response from the NetApp
         """
-        
+
         if args is None:
             merged_args = {"gstreamer": True}
         else:
@@ -58,11 +61,11 @@ class NetAppClientGstreamer(NetAppClient):
                 self.disconnect()
                 raise FailedToConnect(f"{resp.status_code}: {err}")
             # checks if gstreamer port was returned
-            if "port" in data:                
+            if "port" in data:
                 self.gstreamer_port = data["port"]
             else:
                 raise FailedToConnect(f"{resp.status_code}: could not obtain the gstreamer port number")
-        
+
         else:
             self.disconnect()
             raise FailedToConnect(f"{resp.status_code}: unknown error")

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer.py
@@ -1,7 +1,7 @@
 import cv2
 
 
-class DataSenderGStreamer():
+class DataSenderGStreamer:
     """
     Class which setups gstreamer connection to the NetApp allowing
     to send image frames using the OpenCV VideoWriter.
@@ -18,20 +18,20 @@ class DataSenderGStreamer():
             threads (int): the number of threads to be used to encode the h264 stream. 
                 Defaults to 1
         """
-        
+
         self.host = host
         self.port = port
         self.fps = fps
         self.threads = threads
         self.width = width
         self.height = height
-        
+
         # default pipeline for sending h264 encoded stream
-        # ultrafast and zerolatency params for near real-time processing
+        # ultrafast and zero latency params for near real-time processing
         gst_str_rtp = 'appsrc ! videoconvert ! queue ! x264enc ' + \
-            'speed-preset=ultrafast  tune=zerolatency  byte-stream=true ' + \
-            f'threads={self.threads} key-int-max=15 intra-refresh=true ! h264parse ! ' + \
-            f'rtph264pay ! queue ! udpsink host={self.host} port={self.port}'
+                      'speed-preset=ultrafast  tune=zerolatency  byte-stream=true ' + \
+                      f'threads={self.threads} key-int-max=15 intra-refresh=true ! h264parse ! ' + \
+                      f'rtph264pay ! queue ! udpsink host={self.host} port={self.port}'
         self.out = cv2.VideoWriter(gst_str_rtp, cv2.CAP_GSTREAMER, 0, fps, (width, height), True)
 
     def send_image(self, frame):

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_file.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_file.py
@@ -7,33 +7,36 @@ class DataSenderGStreamerFromFile(Thread):
     """
     Class which setups gstreamer connection to the NetApp and
     sends the data from the gstreamer source.
-
     """
 
-    def __init__(self, ip: str, port: int, fps: float, file_name: str, width: int, height: int, resize:bool = True, threads:int = 1):
+    def __init__(self, ip: str, port: int, fps: float, file_name: str, width: int, height: int, resize: bool = True,
+                 threads: int = 1):
         """
         Constructor
 
         Args:
             ip (str): ip address or hostname of the NetApp interface
             port (int): the port assigned for gstreamer communication
-            data_source (str): the gstreamer source, e.g. v4l2src device=/dev/video0
             fps (float): the requested FPS of the h264 stream
+            file_name (str): the gstreamer source, e.g. v4l2src device=/dev/video0
             width (int): the width (in pixels) the video should be resized to (if resize=True) or the
                 actual width of the video (if resize=False)
             height (int): the height (in pixels) the video should be resized to (if resize=True) or the
                 actual height of the video (if resize=False)
             resize (bool): indicates if the video should be resized before sending. If False, 
-                the width and heigth parameters must contain the actual resolution of the video
+                the width and height parameters must contain the actual resolution of the video
             threads (int, optional): the number of threads to be used to encode the h264 stream. 
                 Defaults to 1.
         """
 
         # instantiate the base data sender object
         self.data_sender_gstreamer = DataSenderGStreamer(ip, port, fps, width, height)
-        
-        # creates the videcapture and runs the thread
+
+        # creates the video capture and runs the thread
         self.cap = cv2.VideoCapture(file_name)
+        if not self.cap.isOpened():
+            raise Exception("Cannot open video file")
+
         self.alive = True
         self.resize = resize
         t = Thread(target=self.run, args=())
@@ -46,15 +49,13 @@ class DataSenderGStreamerFromFile(Thread):
         """
         while True:
             ret, frame = self.cap.read()
-            if self.resize:
-                resized = cv2.resize(frame, (self.data_sender_gstreamer.width, self.data_sender_gstreamer.height), 
-                                     interpolation = cv2.INTER_AREA)
-            if ret == False:
+            if not ret:
                 break
             if self.resize:
+                resized = cv2.resize(frame, (self.data_sender_gstreamer.width, self.data_sender_gstreamer.height),
+                                     interpolation=cv2.INTER_AREA)
                 self.data_sender_gstreamer.send_image(resized)
             else:
                 self.data_sender_gstreamer.send_image(frame)
-            
-                
+
         self.alive = False

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_file.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_file.py
@@ -1,6 +1,7 @@
 from threading import Thread
-from .data_sender_gstreamer import DataSenderGStreamer
 import cv2
+
+from .data_sender_gstreamer import DataSenderGStreamer
 
 
 class DataSenderGStreamerFromFile(Thread):
@@ -37,17 +38,22 @@ class DataSenderGStreamerFromFile(Thread):
         if not self.cap.isOpened():
             raise Exception("Cannot open video file")
 
+        self.stopped = False
         self.alive = True
         self.resize = resize
         t = Thread(target=self.run, args=())
         t.daemon = True
         t.start()
 
+    def stop(self):
+        self.stopped = True
+
     def run(self):
         """
         Reads the data from the gstreamer source and sends it using the base data sender
         """
-        while True:
+
+        while not self.stopped:
             ret, frame = self.cap.read()
             if not ret:
                 break

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_source.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_source.py
@@ -7,10 +7,10 @@ class DataSenderGStreamerFromSource(Thread):
     """
     Class which setups gstreamer connection to the NetApp and
     sends the data from the gstreamer source.
-
     """
 
-    def __init__(self, ip: str, port: int, data_source: str, fps: float, width: int, height: int, resize:bool = True, threads:int = 1):
+    def __init__(self, ip: str, port: int, data_source: str, fps: float, width: int, height: int, resize: bool = True,
+                 threads: int = 1):
         """
         Constructor
 
@@ -24,7 +24,7 @@ class DataSenderGStreamerFromSource(Thread):
             height (int): the height (in pixels) the frame of the stream should be resized to 
                 (if resize=True) or the actual height of the frames in stream (if resize=False)
             resize (bool): indicates if the frames in the stream should be resized before sending. 
-                If False, the width and heigth parameters must contain the actual resolution of 
+                If False, the width and height parameters must contain the actual resolution of
                 the frames in the stream
             threads (int, optional): the number of threads to be used to encode the h264 stream. 
                 Defaults to 1.
@@ -32,9 +32,12 @@ class DataSenderGStreamerFromSource(Thread):
 
         # instantiate the base data sender object
         self.data_sender_gstreamer = DataSenderGStreamer(ip, port, fps, width, height)
-       
-        # creates the videcapture and runs the thread
+
+        # creates the video capture and runs the thread
         self.cap = cv2.VideoCapture(data_source, cv2.CAP_GSTREAMER)
+        if not self.cap.isOpened():
+            raise Exception("Cannot open video stream")
+
         self.resize = resize
         t = Thread(target=self.run, args=())
         t.daemon = True
@@ -46,12 +49,11 @@ class DataSenderGStreamerFromSource(Thread):
         """
         while True:
             ret, frame = self.cap.read()
-            if self.resize:
-                resized = cv2.resize(frame, (self.data_sender_gstreamer.width, self.data_sender_gstreamer.height), 
-                                     interpolation = cv2.INTER_AREA)
-            if ret == False:
+            if not ret:
                 break
             if self.resize:
+                resized = cv2.resize(frame, (self.data_sender_gstreamer.width, self.data_sender_gstreamer.height),
+                                     interpolation=cv2.INTER_AREA)
                 self.data_sender_gstreamer.send_image(resized)
             else:
                 self.data_sender_gstreamer.send_image(frame)

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_source.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/data_sender_gstreamer_from_source.py
@@ -38,16 +38,22 @@ class DataSenderGStreamerFromSource(Thread):
         if not self.cap.isOpened():
             raise Exception("Cannot open video stream")
 
+        self.stopped = False
+        self.alive = True
         self.resize = resize
         t = Thread(target=self.run, args=())
         t.daemon = True
         t.start()
 
+    def stop(self):
+        self.stopped = True
+
     def run(self):
         """
         Reads the data from the gstreamer source and sends it using the base data sender
         """
-        while True:
+
+        while not self.stopped:
             ret, frame = self.cap.read()
             if not ret:
                 break
@@ -57,3 +63,5 @@ class DataSenderGStreamerFromSource(Thread):
                 self.data_sender_gstreamer.send_image(resized)
             else:
                 self.data_sender_gstreamer.send_image(frame)
+
+        self.alive = False

--- a/src/python/era_5g_netapp_client/era_5g_netapp_client/middleware_resource_checker.py
+++ b/src/python/era_5g_netapp_client/era_5g_netapp_client/middleware_resource_checker.py
@@ -4,9 +4,10 @@ import requests
 from requests import HTTPError
 import time
 
+
 class MiddlewareResourceChecker(ThreadBase):
 
-    def __init__(self, logger, name, token, action_plan_id, status_endpoint:str, state_callback: Callable = None):
+    def __init__(self, logger, name, token, action_plan_id, status_endpoint: str, state_callback: Callable = None):
         super().__init__(logger, name)
         self.token = token
         self.action_plan_id = action_plan_id
@@ -19,7 +20,7 @@ class MiddlewareResourceChecker(ThreadBase):
     def _run(self):
         while True:
             resource_state = self.getResourceStatus()
-            
+
             seq = resource_state.get('ActionSequence', [])
             if len(seq) > 0:
                 services = seq[0].get("Services", [])
@@ -30,8 +31,8 @@ class MiddlewareResourceChecker(ThreadBase):
 
             if self.state_callback:
                 self.state_callback(self.resource_state)
-            time.sleep(0.5) # TODO: adjust or use somehting similar to rospy.rate.sleep()
-    
+            time.sleep(0.5)  # TODO: adjust or use something similar to rospy.rate.sleep()
+
     def getResourceStatus(self):
         try:  # query orchestrator for latest information regarding the status of resources.
             hed = {'Authorization': 'Bearer ' + str(self.token)}
@@ -44,15 +45,12 @@ class MiddlewareResourceChecker(ThreadBase):
 
     def wait_until_resource_ready(self, timeout: int = -1):
         while True:
-            #if timeout < 0 and time.time() < timeout:
+            # if timeout < 0 and time.time() < timeout:
             #    raise TimeoutError
-            
+
             if self.is_ready():
                 return
             time.sleep(0.1)
 
     def is_ready(self):
         return self.status == "Active"
-
-
-

--- a/src/python/era_5g_netapp_client/requirement.txt
+++ b/src/python/era_5g_netapp_client/requirement.txt
@@ -1,1 +1,2 @@
 requests
+websocket-client

--- a/src/python/era_5g_netapp_client/tests/test_client_gstreamer.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_gstreamer.py
@@ -1,9 +1,11 @@
-
-from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource 
+from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource
+from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStreamerFromFile
 from era_5g_netapp_client.client_gstreamer import NetAppClientGstreamer
 from era_5g_netapp_client.client import FailedToConnect
 import traceback
-import time
+
+FROM_SOURCE = False  # Video from source
+
 
 def get_results(results: str):
     """
@@ -15,50 +17,47 @@ def get_results(results: str):
     print(results)
     pass
 
+
 def main():
     """
     Creates the client class and starts the data transfer
     """
 
-    # IP address or hostname of the server
-    server_ip = "IP_OR_HOSTNAME"
-    user = "GUID"
-    password = "passwd"
-
+    # ip address or hostname of the server (middleware)
+    server_ip = "localhost"
+    user = "2c63955e-27cf-4b9a-980b-b70a54281d15"
+    password = "test"
     task_id = "7d93728a-4a4c-4dae-8245-16b86f85b246"
-    
-    # if middleware is omitted, the netapp address and port has to be specified manually
-    #netapp_uri = "127.0.0.1"
-    #netapp_port = "5896"  
+    # to avoid exception in "except"
+    client = None
 
     try:
-        # to avoid exception in "except"
-        client = None
         # creates the NetApp client with gstreamer extension
-        client = NetAppClientGstreamer(server_ip, user, password, task_id, True, get_results, True, True)
+        client = NetAppClientGstreamer(server_ip, user, password, task_id, "True", get_results, True, True)
         # register the client with the NetApp
         client.register()
-        # creates a data sender which will pass images to the NetApp either from webcamera ...
-                
-        data_src = f"v4l2src device=/dev/video0 ! video/x-raw, format=YUY2, width=640, height=480, " + \
-                    "pixel-aspect-ratio=1/1 ! videoconvert ! appsink"
-        sender = DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480, False)
-        
-        # ... or from file
-        
-        #sender = DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15, "/path/to/the/file.ext", 640, 480)
+        if FROM_SOURCE:
+            # creates a data sender which will pass images to the NetApp either from webcam ...
+            data_src = f"v4l2src device=/dev/video0 ! video/x-raw, format=YUY2, width=640, height=480, " + \
+                       "pixel-aspect-ratio=1/1 ! videoconvert ! appsink"
+            DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480,
+                                          False)
+        else:
+            # or from file
+            DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15,
+                                        "../../../../assets/2017_01_02_001021_s.mp4", 640, 480)
         # waits infinitely
         client.wait()
     except FailedToConnect as ex:
         print(f"Failed to connect to server ({ex})")
-    except KeyboardInterrupt as ex:
+    except KeyboardInterrupt:
         print("Terminating...")
     except Exception as ex:
         traceback.print_exc()
-        print(f"Failed to create client instance ({ex})") 
+        print(f"Failed to create client instance ({ex})")
     finally:
         if client is not None:
-            client.disconnect() 
+            client.disconnect()
 
 
 if __name__ == '__main__':

--- a/src/python/era_5g_netapp_client/tests/test_client_gstreamer.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_gstreamer.py
@@ -1,11 +1,25 @@
+import traceback
+import signal
+import os
+
 from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource
 from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStreamerFromFile
 from era_5g_netapp_client.client_gstreamer import NetAppClientGstreamer
 from era_5g_netapp_client.client import FailedToConnect
-import traceback
-import signal
 
-FROM_SOURCE = False  # Video from source
+# Video from source flag
+FROM_SOURCE = os.getenv("FROM_SOURCE", False)
+# ip address or hostname of the middleware server
+MIDDLEWARE_ADDRESS = os.getenv("MIDDLEWARE_ADDRESS", "127.0.0.1")
+# middleware user
+MIDDLEWARE_USER = os.getenv("MIDDLEWARE_USER", "00000000-0000-0000-0000-000000000000")
+# middleware password
+MIDDLEWARE_PASSWORD = os.getenv("MIDDLEWARE_PASSWORD", "password")
+# middleware NetApp id (task id)
+MIDDLEWARE_TASK_ID = os.getenv("MIDDLEWARE_TASK_ID", "00000000-0000-0000-0000-000000000000")
+# test video file
+TEST_VIDEO_FILE = os.getenv("TEST_VIDEO_FILE", "../../../../assets/2017_01_02_001021_s.mp4")
+
 
 def get_results(results: str):
     """
@@ -14,6 +28,7 @@ def get_results(results: str):
     Args:
         results (str): The results in json format
     """
+
     print(results)
     pass
 
@@ -23,40 +38,34 @@ def main():
     Creates the client class and starts the data transfer
     """
 
-    # ip address or hostname of the middleware server
-    server_ip = "butcluster.ddns.net"
-    # middleware user
-    user = "2c63955e-27cf-4b9a-980b-b70a54281d15"
-    # middleware password
-    password = "test"
-    # middleware NetApp id (task id)
-    task_id = "7d93728a-4a4c-4dae-8245-16b86f85b246"
-    # to avoid exception in "except"
     client = None
+    sender = None
 
     def signal_handler(sig, frame):
-        print('Terminating (SIGTERM)...')
+        print(f"Terminating ({signal.Signals(sig).name})...")
+        if sender is not None:
+            sender.stop()
         if client is not None:
             client.disconnect()
-        exit()
+
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
     try:
         # creates the NetApp client with gstreamer extension
-        client = NetAppClientGstreamer(server_ip, user, password, task_id, True, get_results, True, True)
+        client = NetAppClientGstreamer(MIDDLEWARE_ADDRESS, MIDDLEWARE_USER, MIDDLEWARE_PASSWORD, MIDDLEWARE_TASK_ID, True, get_results, True, True)
         # register the client with the NetApp
         client.register()
         if FROM_SOURCE:
             # creates a data sender which will pass images to the NetApp either from webcam ...
             data_src = f"v4l2src device=/dev/video0 ! video/x-raw, format=YUY2, width=640, height=480, " + \
                        "pixel-aspect-ratio=1/1 ! videoconvert ! appsink"
-            DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480,
-                                          False)
+            sender = DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480,
+                                                   False)
         else:
             # or from file
-            DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15,
-                                        "../../../../assets/2017_01_02_001021_s.mp4", 640, 480)
+            sender = DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15,
+                                                 TEST_VIDEO_FILE, 640, 480)
         # waits infinitely
         client.wait()
     except FailedToConnect as ex:

--- a/src/python/era_5g_netapp_client/tests/test_client_gstreamer.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_gstreamer.py
@@ -3,9 +3,9 @@ from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStre
 from era_5g_netapp_client.client_gstreamer import NetAppClientGstreamer
 from era_5g_netapp_client.client import FailedToConnect
 import traceback
+import signal
 
 FROM_SOURCE = False  # Video from source
-
 
 def get_results(results: str):
     """
@@ -23,17 +23,28 @@ def main():
     Creates the client class and starts the data transfer
     """
 
-    # ip address or hostname of the server (middleware)
-    server_ip = "localhost"
+    # ip address or hostname of the middleware server
+    server_ip = "butcluster.ddns.net"
+    # middleware user
     user = "2c63955e-27cf-4b9a-980b-b70a54281d15"
+    # middleware password
     password = "test"
+    # middleware NetApp id (task id)
     task_id = "7d93728a-4a4c-4dae-8245-16b86f85b246"
     # to avoid exception in "except"
     client = None
 
+    def signal_handler(sig, frame):
+        print('Terminating (SIGTERM)...')
+        if client is not None:
+            client.disconnect()
+        exit()
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
     try:
         # creates the NetApp client with gstreamer extension
-        client = NetAppClientGstreamer(server_ip, user, password, task_id, "True", get_results, True, True)
+        client = NetAppClientGstreamer(server_ip, user, password, task_id, True, get_results, True, True)
         # register the client with the NetApp
         client.register()
         if FROM_SOURCE:

--- a/src/python/era_5g_netapp_client/tests/test_client_gstreamer_no_middleware.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_gstreamer_no_middleware.py
@@ -1,10 +1,11 @@
-
-from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource 
+from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource
 from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStreamerFromFile
 from era_5g_netapp_client.client_gstreamer import NetAppClientGstreamer
 from era_5g_netapp_client.client import FailedToConnect
 import traceback
-import time
+
+FROM_SOURCE = False  # Video from source
+
 
 def get_results(results: str):
     """
@@ -16,6 +17,7 @@ def get_results(results: str):
     print(results)
     pass
 
+
 def main():
     """
     Creates the client class and starts the data transfer
@@ -24,37 +26,38 @@ def main():
     # ip address or hostname of the computer, where the netapp is deployed
     netapp_uri = "127.0.0.1"
     # port of the netapp's server
-    netapp_port = "5896"
+    netapp_port = 5897
+    # to avoid exception in "except"
+    client = None
 
     try:
-        # to avoid exception in "except"
-        client = None
         # creates the NetApp client with gstreamer extension
-        client = NetAppClientGstreamer(None, None, None, None, True, get_results, False, False, netapp_uri, netapp_port)
+        client = NetAppClientGstreamer(None, None, None, None, "True", get_results, False, False, netapp_uri,
+                                       netapp_port)
         # register the client with the NetApp
         client.register()
-        # creates a data sender which will pass images to the NetApp either from webcamera ...
-                
-        #data_src = f"v4l2src device=/dev/video0 ! video/x-raw, format=YUY2, width=640, height=480, " + \
-        #            "pixel-aspect-ratio=1/1 ! videoconvert ! appsink"
-        # sender = DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480, False)
-        
-        # ... or from file
-        
-        sender = DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15, "/path/to/the/file.ext", 640, 480)
-                
+        if FROM_SOURCE:
+            # creates a data sender which will pass images to the NetApp either from webcam ...
+            data_src = f"v4l2src device=/dev/video0 ! video/x-raw, format=YUY2, width=640, height=480, " + \
+                       "pixel-aspect-ratio=1/1 ! videoconvert ! appsink"
+            DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480,
+                                          False)
+        else:
+            # or from file
+            DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15,
+                                        "../../../../assets/2017_01_02_001021_s.mp4", 640, 480)
         # waits infinitely
         client.wait()
     except FailedToConnect as ex:
         print(f"Failed to connect to server ({ex})")
-    except KeyboardInterrupt as ex:
+    except KeyboardInterrupt:
         print("Terminating...")
     except Exception as ex:
         traceback.print_exc()
-        print(f"Failed to create client instance ({ex})") 
+        print(f"Failed to create client instance ({ex})")
     finally:
         if client is not None:
-            client.disconnect() 
+            client.disconnect()
 
 
 if __name__ == '__main__':

--- a/src/python/era_5g_netapp_client/tests/test_client_gstreamer_no_middleware.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_gstreamer_no_middleware.py
@@ -3,6 +3,7 @@ from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStre
 from era_5g_netapp_client.client_gstreamer import NetAppClientGstreamer
 from era_5g_netapp_client.client import FailedToConnect
 import traceback
+import signal
 
 FROM_SOURCE = False  # Video from source
 
@@ -30,9 +31,17 @@ def main():
     # to avoid exception in "except"
     client = None
 
+    def signal_handler(sig, frame):
+        print(f"Terminating ({signal.Signals(sig).name})...")
+        if client is not None:
+            client.disconnect()
+        exit()
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
     try:
         # creates the NetApp client with gstreamer extension
-        client = NetAppClientGstreamer(None, None, None, None, "True", get_results, False, False, netapp_uri,
+        client = NetAppClientGstreamer(None, None, None, None, True, get_results, False, False, netapp_uri,
                                        netapp_port)
         # register the client with the NetApp
         client.register()

--- a/src/python/era_5g_netapp_client/tests/test_client_gstreamer_no_middleware.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_gstreamer_no_middleware.py
@@ -1,11 +1,20 @@
+import traceback
+import signal
+import os
+
 from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource
 from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStreamerFromFile
 from era_5g_netapp_client.client_gstreamer import NetAppClientGstreamer
 from era_5g_netapp_client.client import FailedToConnect
-import traceback
-import signal
 
-FROM_SOURCE = False  # Video from source
+# Video from source flag
+FROM_SOURCE = False
+# ip address or hostname of the computer, where the netapp is deployed
+NETAPP_ADDRESS = os.getenv("NETAPP_ADDRESS", "127.0.0.1")
+# port of the netapp's server
+NETAPP_PORT = os.getenv("NETAPP_PORT", 5896)
+# test video file
+TEST_VIDEO_FILE = os.getenv("TEST_VIDEO_FILE", "../../../../assets/2017_01_02_001021_s.mp4")
 
 
 def get_results(results: str):
@@ -24,37 +33,35 @@ def main():
     Creates the client class and starts the data transfer
     """
 
-    # ip address or hostname of the computer, where the netapp is deployed
-    netapp_uri = "127.0.0.1"
-    # port of the netapp's server
-    netapp_port = 5897
-    # to avoid exception in "except"
     client = None
+    sender = None
 
     def signal_handler(sig, frame):
         print(f"Terminating ({signal.Signals(sig).name})...")
+        if sender is not None:
+            sender.stop()
         if client is not None:
             client.disconnect()
-        exit()
+
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
     try:
         # creates the NetApp client with gstreamer extension
-        client = NetAppClientGstreamer(None, None, None, None, True, get_results, False, False, netapp_uri,
-                                       netapp_port)
+        client = NetAppClientGstreamer(None, None, None, None, True, get_results, False, False, NETAPP_ADDRESS,
+                                       NETAPP_PORT)
         # register the client with the NetApp
         client.register()
         if FROM_SOURCE:
             # creates a data sender which will pass images to the NetApp either from webcam ...
             data_src = f"v4l2src device=/dev/video0 ! video/x-raw, format=YUY2, width=640, height=480, " + \
                        "pixel-aspect-ratio=1/1 ! videoconvert ! appsink"
-            DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480,
-                                          False)
+            sender = DataSenderGStreamerFromSource(client.netapp_host, client.gstreamer_port, data_src, 15, 640, 480,
+                                                   False)
         else:
             # or from file
-            DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15,
-                                        "../../../../assets/2017_01_02_001021_s.mp4", 640, 480)
+            sender = DataSenderGStreamerFromFile(client.netapp_host, client.gstreamer_port, 15,
+                                                 TEST_VIDEO_FILE, 640, 480)
         # waits infinitely
         client.wait()
     except FailedToConnect as ex:
@@ -62,7 +69,7 @@ def main():
     except KeyboardInterrupt:
         print("Terminating...")
     except Exception as ex:
-        traceback.print_exc()
+        #traceback.print_exc()
         print(f"Failed to create client instance ({ex})")
     finally:
         if client is not None:

--- a/src/python/era_5g_netapp_client/tests/test_client_http.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_http.py
@@ -88,7 +88,7 @@ def main():
 
     try:
         # creates the NetApp client with gstreamer extension
-        client = NetAppClient(None, None, None, None, "True", get_results, False, False, netapp_uri, netapp_port)
+        client = NetAppClient(None, None, None, None, True, get_results, False, False, netapp_uri, netapp_port)
         # register the client with the NetApp
         client.register()
         if FROM_SOURCE:

--- a/src/python/era_5g_netapp_client/tests/test_client_http.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_http.py
@@ -1,24 +1,31 @@
-from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource
-from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStreamerFromFile
-from era_5g_netapp_client.client import FailedToConnect, NetAppClient
 import traceback
 import math
 import time
 import cv2
-
+import signal
 from queue import Queue
-
-from era_5g_netapp_interface.common import ThreadBase, get_logger
 import logging
+import os
+
+from era_5g_netapp_client.client import FailedToConnect, NetAppClient
+from era_5g_netapp_interface.common import ThreadBase, get_logger
 
 image_storage = dict()
 results_storage = Queue()
 
+logger = get_logger(log_level=logging.INFO)
+
 DEBUG_PRINT_SCORE = False  # useful for FPS detector
 DEBUG_PRINT_DELAY = False  # prints the delay between capturing image and receiving the results
-FROM_SOURCE = False  # Video from source
 
-logger = get_logger(log_level=logging.INFO)
+# Video from source flag
+FROM_SOURCE = False
+# ip address or hostname of the computer, where the netapp is deployed
+NETAPP_ADDRESS = os.getenv("NETAPP_ADDRESS", "127.0.0.1")
+# port of the netapp's server
+NETAPP_PORT = os.getenv("NETAPP_PORT", 5896)
+# test video file
+TEST_VIDEO_FILE = os.getenv("TEST_VIDEO_FILE", "../../../../assets/2017_01_02_001021_s.mp4")
 
 
 class ResultsViewer(ThreadBase):
@@ -66,6 +73,7 @@ def get_results(results: str):
     Args:
         results (str): The results in json format
     """
+
     print(results)
     if 'timestamp' in results:
         results_storage.put(results, block=False)
@@ -77,18 +85,24 @@ def main():
     Creates the client class and starts the data transfer
     """
 
-    # ip address or hostname of the computer, where the netapp is deployed
-    netapp_uri = "127.0.0.1"
-    # port of the netapp's server
-    netapp_port = 5897
     results_viewer = ResultsViewer(logger, "viewer")
     results_viewer.start(daemon=False)
-    # to avoid exception in "except"
+
     client = None
+    global stopped
+    stopped = False
+
+    def signal_handler(sig, frame):
+        global stopped
+        stopped = True
+        results_viewer.stop()
+        print(f"Terminating ({signal.Signals(sig).name})...")
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
 
     try:
         # creates the NetApp client with gstreamer extension
-        client = NetAppClient(None, None, None, None, True, get_results, False, False, netapp_uri, netapp_port)
+        client = NetAppClient(None, None, None, None, True, get_results, False, False, NETAPP_ADDRESS, NETAPP_PORT)
         # register the client with the NetApp
         client.register()
         if FROM_SOURCE:
@@ -98,31 +112,28 @@ def main():
                 raise Exception("Cannot open camera")
         else:
             # or from video file
-            cap = cv2.VideoCapture("../../../../assets/2017_01_02_001021_s.mp4")
+            cap = cv2.VideoCapture(TEST_VIDEO_FILE)
             if not cap.isOpened():
                 raise Exception("Cannot open video file")
 
-        while True:
+        while not stopped:
             ret, frame = cap.read()
             timestamp = math.floor(time.time() * 100)
             if not ret:
                 break
             resized = cv2.resize(frame, (640, 480), interpolation=cv2.INTER_AREA)
-
             image_storage[timestamp] = resized
             client.send_image(resized, str(timestamp), 5)
 
     except FailedToConnect as ex:
         print(f"Failed to connect to server ({ex})")
-        results_viewer.stop()
     except KeyboardInterrupt:
         print("Terminating...")
-        results_viewer.stop()
     except Exception as ex:
         traceback.print_exc()
         print(f"Failed to create client instance ({ex})")
-        results_viewer.stop()
     finally:
+        results_viewer.stop()
         if client is not None:
             client.disconnect()
 

--- a/src/python/era_5g_netapp_client/tests/test_client_http.py
+++ b/src/python/era_5g_netapp_client/tests/test_client_http.py
@@ -1,4 +1,4 @@
-from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource 
+from era_5g_netapp_client.data_sender_gstreamer_from_source import DataSenderGStreamerFromSource
 from era_5g_netapp_client.data_sender_gstreamer_from_file import DataSenderGStreamerFromFile
 from era_5g_netapp_client.client import FailedToConnect, NetAppClient
 import traceback
@@ -14,43 +14,50 @@ import logging
 image_storage = dict()
 results_storage = Queue()
 
-DEBUG_PRINT_SCORE = False # usefull for FPS detector 
-DEBUG_PRINT_DELAY = False # prints the delay between capturing image and recieving the results 
+DEBUG_PRINT_SCORE = False  # useful for FPS detector
+DEBUG_PRINT_DELAY = False  # prints the delay between capturing image and receiving the results
+FROM_SOURCE = False  # Video from source
 
 logger = get_logger(log_level=logging.INFO)
+
 
 class ResultsViewer(ThreadBase):
 
     def __init__(self, logger, name):
         super().__init__(logger, name)
+        self.stopped = False
 
     def run(self):
-        while True:  
-            results = results_storage.get()
-            timestamp = int(results['timestamp'])
-            if DEBUG_PRINT_DELAY:
-                time_now = math.floor(time.time()*100)
-                print(f"{(time_now - timestamp) / 100.}s delay")
-            try:
-                frame = image_storage.pop(timestamp)
-                detections = results["detections"]
-                for d in detections:
-                    score = d["score"]
-                    if DEBUG_PRINT_SCORE and score > 0:
-                        print(score)
-                    cls_name = d["class_name"]
-                    # Draw detection into frame.
-                    x1, y1, x2, y2 = [int(coord) for coord in d["bbox"]]
-                    cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 1)
-                    font = cv2.FONT_HERSHEY_SIMPLEX
-                    cv2.putText(frame, f"{cls_name} ({score*100:.0f})%", (x1, y1-5), font, .5, (0, 255, 0), 1, cv2.LINE_AA)
+        while not self.stopped:
+            if not results_storage.empty():
+                results = results_storage.get(timeout=1)
+                timestamp = int(results['timestamp'])
+                if DEBUG_PRINT_DELAY:
+                    time_now = math.floor(time.time() * 100)
+                    print(f"{(time_now - timestamp) / 100.}s delay")
+                try:
+                    frame = image_storage.pop(timestamp)
+                    detections = results["detections"]
+                    for d in detections:
+                        score = d["score"]
+                        if DEBUG_PRINT_SCORE and score > 0:
+                            print(score)
+                        cls_name = d["class_name"]
+                        # Draw detection into frame.
+                        x1, y1, x2, y2 = [int(coord) for coord in d["bbox"]]
+                        cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 1)
+                        font = cv2.FONT_HERSHEY_SIMPLEX
+                        cv2.putText(frame, f"{cls_name} ({score * 100:.0f})%", (x1, y1 - 5), font, .5, (0, 255, 0), 1,
+                                    cv2.LINE_AA)
+                    try:
+                        cv2.imshow("Results", frame)
+                        cv2.waitKey(1)
+                    except Exception as ex:
+                        print(ex)
+                    results_storage.task_done()
+                except KeyError as ex:
+                    print(ex)
 
-                cv2.imshow("Results", frame)
-                cv2.waitKey(1)
-                results_storage.task_done()
-            except KeyError as ex:
-                print(ex)
-            
 
 def get_results(results: str):
     """
@@ -59,10 +66,10 @@ def get_results(results: str):
     Args:
         results (str): The results in json format
     """
+    print(results)
     if 'timestamp' in results:
         results_storage.put(results, block=False)
     pass
-        
 
 
 def main():
@@ -73,45 +80,51 @@ def main():
     # ip address or hostname of the computer, where the netapp is deployed
     netapp_uri = "127.0.0.1"
     # port of the netapp's server
-    netapp_port = "5896"
-
+    netapp_port = 5897
     results_viewer = ResultsViewer(logger, "viewer")
     results_viewer.start(daemon=False)
+    # to avoid exception in "except"
+    client = None
 
     try:
-        # to avoid exception in "except"
-        client = None
         # creates the NetApp client with gstreamer extension
-        client = NetAppClient(None, None, None, None, True, get_results, False, False, netapp_uri, netapp_port)
+        client = NetAppClient(None, None, None, None, "True", get_results, False, False, netapp_uri, netapp_port)
         # register the client with the NetApp
         client.register()
-        # creates a vide capture to pass images to the NetApp either from webcamera ...
-        cap = cv2.VideoCapture(0)
+        if FROM_SOURCE:
+            # creates a video capture to pass images to the NetApp either from webcam ...
+            cap = cv2.VideoCapture(0)
+            if not cap.isOpened():
+                raise Exception("Cannot open camera")
+        else:
+            # or from video file
+            cap = cv2.VideoCapture("../../../../assets/2017_01_02_001021_s.mp4")
+            if not cap.isOpened():
+                raise Exception("Cannot open video file")
 
-        # or from videofile
-        #cap = cv2.VideoCapture("/path/to/file")
-        
-                
         while True:
             ret, frame = cap.read()
-            timestamp = math.floor(time.time()*100)
-            if ret == False:
+            timestamp = math.floor(time.time() * 100)
+            if not ret:
                 break
-            resized = cv2.resize(frame, (640, 480), interpolation = cv2.INTER_AREA)
-            
+            resized = cv2.resize(frame, (640, 480), interpolation=cv2.INTER_AREA)
+
             image_storage[timestamp] = resized
-            client.send_image(resized, timestamp, 5)
-            
+            client.send_image(resized, str(timestamp), 5)
+
     except FailedToConnect as ex:
         print(f"Failed to connect to server ({ex})")
-    except KeyboardInterrupt as ex:
+        results_viewer.stop()
+    except KeyboardInterrupt:
         print("Terminating...")
+        results_viewer.stop()
     except Exception as ex:
         traceback.print_exc()
-        print(f"Failed to create client instance ({ex})") 
+        print(f"Failed to create client instance ({ex})")
+        results_viewer.stop()
     finally:
         if client is not None:
-            client.disconnect() 
+            client.disconnect()
 
 
 if __name__ == '__main__':

--- a/src/python/era_5g_netapp_interface/era_5g_netapp_interface/common.py
+++ b/src/python/era_5g_netapp_interface/era_5g_netapp_interface/common.py
@@ -1,22 +1,21 @@
-# -*- encoding: utf8 -*-
 import datetime
 import os
-from threading import Thread, Event
+from threading import Thread
 import logging
-
+from logging import Logger
 from pkg_resources import ensure_directory
+from typing import Union
 
 
-
-def get_logger(log_level, logdir = None, deploy = False):
+def get_logger(log_level: Union[int, str], logdir: str = None, deploy: bool = False) -> Logger:
     """
     Gets logger for thread-based classes.
 
     Args:
-        log_level (_type_): Sets the threshold for this logger to level. 
+        log_level (Union[int, str]): Sets the threshold for this logger to level.
             Logging messages which are less severe than level will be ignored.
             Possible levels are CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
-        logdir (_type_, optional): If set, the logs will be saved to this directory. 
+        logdir (str, optional): If set, the logs will be saved to this directory.
             Defaults to None.
         deploy (bool, optional): TBA. Defaults to False.
 
@@ -40,31 +39,33 @@ def get_logger(log_level, logdir = None, deploy = False):
         file_handler.setLevel(log_level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
-    
+
     return logger
+
 
 class ThreadBase(Thread):
     """
     Base Thread class which provides handy methods.
-
     """
-    def __init__(self, logger, name):
+
+    def __init__(self, logger: Logger, name: str = None):
         """
         Constructor
 
         Args:
-            logger (_type_): A thread-safe logger. Could be obtained using the 
+            logger (Logger): A thread-safe logger. Could be obtained using the
                 era_5g_netapp_interface.common.get_logger() function.
-            name (_type_): Name of the thread
+            name (str): Name of the thread
         """
+
         super().__init__()
+        self._monitoring = None
+        self._print = False
         self.stopped = False
         self._stopped = False
         self.logger = logger
-        self.name = name
-        self._print = False
+        self.name = str(name or super().getName())
 
-        
     def send_state(self):
         if self._monitoring:
             self._send_state()
@@ -75,30 +76,28 @@ class ThreadBase(Thread):
 
     def set_monitoring(self, _monitoring):
         self._monitoring = _monitoring
-        return 
+        return
 
     def set_print(self, _print):
         self._print = _print
         return
-        
+
     def stop(self):
         self.logger.debug("Stopping %s thread", self.name)
         self.stopped = True
-
 
     def stop_base(self):
         self.logger.debug("Stopping %s thread", self.name)
         self._stopped = True
 
-    
     def start(self, daemon: bool):
         self.logger.debug("Starting %s thread", self.name)
         t = Thread(target=self.run, args=())
         t.daemon = daemon
         t.start()
-        
+
     def run(self):
         self._run()
-        
+
     def _run(self):
         pass

--- a/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler.py
+++ b/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler.py
@@ -1,40 +1,31 @@
-from threading import Thread
-from abc import abstractmethod, ABCMeta
+from abc import abstractmethod, ABC
+from logging import Logger
+
+from era_5g_netapp_interface.common import ThreadBase
 
 
-class TaskHanlderInitializationFailed(Exception):
+class TaskHandlerInitializationFailed(Exception):
     pass
 
-class TaskHandler(Thread):
+
+class TaskHandler(ThreadBase, ABC):
     """
     Abstract class. Thread-based task handler which takes care
-    of recieving data from the NetApp client and passing them 
+    of receiving data from the NetApp client and passing them
     to the NetApp worker.
-
     """
-    __metaclass__ = ABCMeta
 
-    def __init__(self, logger, sid):
-        super().__init__()
+    def __init__(self, logger: Logger, sid: str):
+        super().__init__(logger=logger, name=sid)
         self.sid = sid
         self.websocket_id = None
         self.logger = logger
 
-    def start(self, daemon):
-        self.logger.debug("Starting %s thread", self.name)
-        t = Thread(target=self._run, args=())
-        t.daemon = daemon
-        t.start()
-
-    def stop(self):
-        self.logger.debug("Stopping %s thread", self.name)
-        self.stopped = True
-
     @abstractmethod
     def _run(self):
         """
-        This method is run once the thread is starded and could be used
-        for periodical retrival of images.
+        This method is run once the thread is started and could be used
+        for periodical retrieval of images.
         """
         pass
 
@@ -50,5 +41,3 @@ class TaskHandler(Thread):
             image (_type_): The image to be processed.
         """
         pass
-
-

--- a/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler_gstreamer.py
+++ b/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler_gstreamer.py
@@ -1,57 +1,61 @@
+from abc import ABC
+from logging import Logger
 import cv2
-from era_5g_netapp_interface.task_handler import TaskHandler, TaskHanlderInitializationFailed
 
-class TaskHandlerGstreamer(TaskHandler):
+from era_5g_netapp_interface.task_handler import TaskHandler, TaskHandlerInitializationFailed
+
+
+class TaskHandlerGstreamer(TaskHandler, ABC):
     """
     Abstract class. Task handler which takes care of reading the data 
     from Gstreamer pipeline with defined parameters. It needs to be 
     inherited to implement the store_image method.
-
     """
 
-    def __init__(self, logger, sid: str, port: str, **kw):
+    def __init__(self, logger: Logger, sid: str, port: str, **kwargs):
         """
         Constructor
 
         Args:
-            logger (_type_): A thread-safe logger. Could be obtained using the 
+            logger (Logger): A thread-safe logger. Could be obtained using the
                 era_5g_netapp_interface.common.get_logger() function.
             sid (str): The session id obtained from NetApp client. It is used to 
                 match the results with the data sender.
             port (str): The port where the Gstreamer pipeline should listen to.
         """
-        super().__init__(logger=logger, sid=sid, **kw)
+
+        super().__init__(logger=logger, sid=sid, **kwargs)
         self.port = port
-        
+
     def _run(self):
         """
         The infinite loop which reads the Gstreamer pipeline and pass the images
         to the store_image method, which has to be implemented in the child class.
 
         Raises:
-            TaskHanlderInitializationFailed: Raised when the construction of 
+            TaskHandlerInitializationFailed: Raised when the construction of
                 Gstreamer pipeline failed
         """
 
         # pipeline which decodes a h264 stream 
-        camSet=f'udpsrc port={self.port} caps="application/x-rtp,media=(string)video,encoding-name=(string)H264,payload=(int)96"   ! rtpjitterbuffer ! rtph264depay ! avdec_h264 ! videorate ! videoconvert ! appsink'
-        
+        camSet = f'udpsrc port={self.port} caps="application/x-rtp,media=(string)video,encoding-name=(string)H264,' \
+                 f'payload=(int)96" ! rtpjitterbuffer ! rtph264depay ! avdec_h264 ! videorate ! videoconvert ! ' \
+                 f'appsink'
+
         try:
             self.logger.info(f"creating capture on port {self.port}")
-            # standard OpenCV VideoCaputre connected to the Gstreamer pipeline
+            # standard OpenCV VideoCapture connected to the Gstreamer pipeline
             cap = cv2.VideoCapture(camSet)
             if not cap.isOpened():
-                raise TaskHanlderInitializationFailed("Videocapture was not opened")
+                raise TaskHandlerInitializationFailed("Videocapture was not opened")
             self.logger.info("capture created")
         except:
             self.logger.info("capture fail")
             exit(1)
 
-        while (True):            
+        while not self.stopped:
             ret, frame = cap.read()
             if ret:
                 # extract the timestamp from the frame
                 timestamp = cap.get(cv2.CAP_PROP_POS_MSEC)
                 self.store_image({"sid": self.sid, "websocket_id": self.websocket_id, "timestamp": timestamp}, frame)
-                
-             

--- a/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler_gstreamer_internal_q.py
+++ b/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler_gstreamer_internal_q.py
@@ -1,22 +1,22 @@
-from threading import Thread
-from queue import Full, Queue
+from queue import Queue
+from logging import Logger
+
 from era_5g_netapp_interface.task_handler_gstreamer import TaskHandlerGstreamer
 from era_5g_netapp_interface.task_handler_internal_q import TaskHandlerInternalQ
 
 
 class TaskHandlerGstreamerInternalQ(TaskHandlerGstreamer, TaskHandlerInternalQ):
     """
-    Task handler which combines the Gstreamer functionality of data retrival
+    Task handler which combines the Gstreamer functionality of data retrieval
     with usage of python internal queues for passing the data to the worker object.
-
-    
     """
 
-    def __init__(self, logger, sid, port: str, image_queue: Queue):
-        """_summary_
+    def __init__(self, logger: Logger, sid: str, port: str, image_queue: Queue):
+        """
+        Constructor
 
         Args:
-            logger (_type_): A thread-safe logger. Could be obtained using the 
+            logger (Logger): A thread-safe logger. Could be obtained using the
                 era_5g_netapp_interface.common.get_logger() function.
             sid (str): The session id obtained from NetApp client. It is used to 
                 match the results with the data sender.
@@ -24,5 +24,6 @@ class TaskHandlerGstreamerInternalQ(TaskHandlerGstreamer, TaskHandlerInternalQ):
             image_queue (Queue): The queue where the image and metadata should 
                 be passed to.
         """
+
         super().__init__(logger=logger, sid=sid, port=port, image_queue=image_queue)
       

--- a/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler_internal_q.py
+++ b/src/python/era_5g_netapp_interface/era_5g_netapp_interface/task_handler_internal_q.py
@@ -1,31 +1,31 @@
-from threading import Thread
 from queue import Full, Queue
+from logging import Logger
+
 from era_5g_netapp_interface.task_handler import TaskHandler
-import cv2
+
 
 class TaskHandlerInternalQ(TaskHandler):
     """
     Task handler which takes care of passing the data to the python 
     internal queue for future processing. It could either be inherited
     to implement the _run method and read the data from any source or used
-    directly and call the store_image method externaly.
+    directly and call the store_image method externally.
     """
 
-    def __init__(self, logger, sid: str, image_queue: Queue, **kw):
+    def __init__(self, logger: Logger, sid: str, image_queue: Queue):
         """
         Constructor
 
         Args:
-            Args:
-            logger (_type_): A thread-safe logger. Could be obtained using the 
+            logger (Logger): A thread-safe logger. Could be obtained using the
                 era_5g_netapp_interface.common.get_logger() function.
             sid (str): The session id obtained from NetApp client. It is used to 
                 match the results with the data sender.
             image_queue (Queue): The queue where the image and metadata should 
                 be passed to.
         """
-        super().__init__(logger=logger, sid=sid, **kw)
 
+        super().__init__(logger=logger, sid=sid)
         self._q = image_queue
         self.index = 0
 
@@ -38,12 +38,12 @@ class TaskHandlerInternalQ(TaskHandler):
                 The format is NetApp-specific.
             image (_type_): The image to be processed.
         """
-        
+
         try:
             self._q.put((metadata, image), block=False)
         except Full:
             pass
             # TODO: raise an exception
-    
+
     def _run(self):
         pass

--- a/src/python/era_5g_object_detection_common/requirement.txt
+++ b/src/python/era_5g_object_detection_common/requirement.txt
@@ -1,7 +1,5 @@
-numpy==1.23.*
+numpy>=1.23.*
 opencv_python==4.6.*
 pycocotools==2.0.*
 setuptools
-simple-websocket
-gevent-websocket
 eventlet

--- a/src/python/era_5g_object_detection_common/requirement.txt
+++ b/src/python/era_5g_object_detection_common/requirement.txt
@@ -1,3 +1,7 @@
 numpy==1.23.*
 opencv_python==4.6.*
 pycocotools==2.0.*
+setuptools
+simple-websocket
+gevent-websocket
+eventlet

--- a/src/python/era_5g_object_detection_distributed_interface/era_5g_object_detection_distributed_interface/interface.py
+++ b/src/python/era_5g_object_detection_distributed_interface/era_5g_object_detection_distributed_interface/interface.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-
+import os
 import logging
 import secrets
 from queue import Queue
@@ -12,6 +11,9 @@ from era_5g_netapp_interface.common import get_logger
 from flask import Flask, Response, request, session
 
 from flask_session import Session
+
+# port of the netapp's server
+NETAPP_PORT = os.getenv("NETAPP_PORT", 5896)
 
 # flask initialization
 app = Flask(__name__)
@@ -120,7 +122,7 @@ def main(args=None):
     # runs the flask server
     # allow_unsafe_werkzeug needs to be true to run inside the docker
     # TODO: use better webserver
-    socketio.run(app, port=5896, host='0.0.0.0', allow_unsafe_werkzeug=True)
+    socketio.run(app, port=NETAPP_PORT, host='0.0.0.0', allow_unsafe_werkzeug=True)
     
 
 

--- a/src/python/era_5g_object_detection_distributed_interface/requirement.txt
+++ b/src/python/era_5g_object_detection_distributed_interface/requirement.txt
@@ -3,4 +3,4 @@ flask_socketio==5.3.*
 flask==2.2.*
 flask_session==0.4.*
 celery==5.2.7
-redis==4.3.4
+redis>=4.3.4

--- a/src/python/era_5g_object_detection_distributed_worker/requirement.txt
+++ b/src/python/era_5g_object_detection_distributed_worker/requirement.txt
@@ -1,4 +1,4 @@
 era_5g_netapp_interface==0.0.1
 era_5g_object_detection_common==0.0.1
 celery==5.2.7
-redis==4.3.4
+redis>=4.3.4

--- a/src/python/era_5g_object_detection_standalone/era_5g_object_detection_standalone/interface.py
+++ b/src/python/era_5g_object_detection_standalone/era_5g_object_detection_standalone/interface.py
@@ -151,9 +151,9 @@ def connect(auth):
     flask_socketio.send("You are connected", namespace='/results', to=sid)
 
 
-@socketio.event
-def disconnect(sid):
-    print('Client disconnected', sid)
+@socketio.on('disconnect', namespace='/results')
+def disconnect():
+    print(f"Client disconnected: session id: {session.sid}, websocket id: {request.sid}")
 
 
 def get_ports_range(ports_range):

--- a/src/python/era_5g_object_detection_standalone/era_5g_object_detection_standalone/interface.py
+++ b/src/python/era_5g_object_detection_standalone/era_5g_object_detection_standalone/interface.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import logging
 import secrets
 from queue import Queue
@@ -7,7 +5,6 @@ import cv2
 import argparse
 
 import numpy as np
-
 
 from era_5g_object_detection_common.image_detector import ImageDetectorInitializationFailed
 
@@ -27,9 +24,9 @@ app.config['SESSION_TYPE'] = 'filesystem'
 
 # socketio initialization for sending results to the client
 Session(app)
-socketio = flask_socketio.SocketIO(app, manage_session=False, async_mode='threading') 
+socketio = flask_socketio.SocketIO(app, manage_session=False, async_mode='threading')
 
-# list of available ports for gstreamer communication - they needs to be exposed when running in docker / k8s
+# list of available ports for gstreamer communication - they need to be exposed when running in docker / k8s
 # could be changed using the script arguments
 free_ports = [5001, 5002, 5003]
 
@@ -42,14 +39,16 @@ image_queue = Queue(30)
 
 logger = get_logger(log_level=logging.INFO)
 
-# is gstreamer used to transpord data?
-gstreamer = False
+# is gstreamer used to transport data?
+#gstreamer = False
 
 # the image detector to be used
 detector_thread = None
 
+
 class ArgFormatError(Exception):
     pass
+
 
 @app.route('/register', methods=['GET'])
 def register():
@@ -59,22 +58,22 @@ def register():
     Returns:
         _type_: The port used for gstreamer communication.
     """
-    if not free_ports:
+    args = request.args.to_dict()
+    gstreamer = args.get("gstreamer", False)
+
+    if gstreamer and not free_ports:
         return {"error": "Not enough resources"}, 503
-    
+
     session['registered'] = True
 
-    args = request.args.to_dict()
-    global gstreamer
-    gstreamer = args.get("gstreamer", False)
-    # select the appropriete task hander, depends on whether the client wants to use 
+    # select the appropriate task handler, depends on whether the client wants to use
     # gstreamer to pass the images or not 
     if gstreamer:
-        port = free_ports.pop(0)  
+        port = free_ports.pop(0)
         task = TaskHandlerGstreamerInternalQ(logger, session.sid, port, image_queue)
     else:
         task = TaskHandlerInternalQ(logger, session.sid, image_queue)
-     
+
     tasks[session.sid] = task
     print(f"Client registered: {session.sid}")
     if gstreamer:
@@ -96,13 +95,13 @@ def unregister():
     if session.pop('registered', None):
         task = tasks.pop(session.sid)
         flask_socketio.disconnect(task.websocket_id, namespace="/results")
-        if gstreamer:
+        if hasattr(task, 'port'):
             free_ports.append(task.port)
         task.stop()
         print(f"Client unregistered: {session_id}")
 
-        
     return Response(status=204)
+
 
 @app.route('/image', methods=['POST'])
 def post_image():
@@ -113,7 +112,7 @@ def post_image():
     """
     sid = session.sid
     task = tasks[sid]
-    
+
     if "timestamps[]" in request.args:
         timestamps = request.args.to_dict(flat=False)['timestamps[]']
     else:
@@ -121,11 +120,11 @@ def post_image():
     # convert string of image data to uint8
     index = 0
     for file in request.files.to_dict(flat=False)['files']:
-        #print(file)    
+        # print(file)
         nparr = np.fromstring(file.read(), np.uint8)
         # decode image
-        img = cv2.imdecode(nparr, cv2.IMREAD_COLOR) 
-        
+        img = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+
         # store the image to the appropriate task
         task.store_image({"sid": sid, "websocket_id": task.websocket_id, "timestamp": timestamps[index]}, img)
         index += 1
@@ -146,17 +145,16 @@ def connect(auth):
         raise ConnectionRefusedError('Need to call /register first.')
 
     sid = request.sid
-
-    print('connect ', sid)
-    print(f"Connected. Session id: {session.sid}, ws_sid: {sid}")
+    print(f"Client connected: session id: {session.sid}, websocket id: {sid}")
     tasks[session.sid].websocket_id = sid
     tasks[session.sid].start(daemon=True)
-    flask_socketio.send("you are connected", namespace='/results', to=sid)
+    flask_socketio.send("You are connected", namespace='/results', to=sid)
 
 
 @socketio.event
 def disconnect(sid):
-    print('disconnect ', sid)
+    print('Client disconnected', sid)
+
 
 def get_ports_range(ports_range):
     if ports_range.count(':') != 1:
@@ -165,23 +163,25 @@ def get_ports_range(ports_range):
     if int(r2) <= int(r1):
         raise ArgFormatError
     return [port for port in range(int(r1), int(r2) + 1)]
-        
 
 
 def main(args=None):
-
     parser = argparse.ArgumentParser(description='Standalone variant of object detection NetApp')
-    parser.add_argument('--ports', default="5001:5003", help="Specify the range of ports available for gstreamer connections. Format port_start:port_end. Default is 5001:5003")
-    parser.add_argument('--detector', default="fps", help="Select detector. Available options are opencv, mmdetection, fps. Default is fps")
+    parser.add_argument('--ports',
+                        default="5001:5003",
+                        help="Specify the range of ports available for gstreamer connections. Format "
+                             "port_start:port_end. Default is 5001:5003.")
+    parser.add_argument('--detector',
+                        default="fps",
+                        help="Select detector. Available options are opencv, mmdetection, fps. Default is fps.")
     args = parser.parse_args()
-    global free_ports
+    global free_ports, detector_thread
     try:
         free_ports = get_ports_range(args.ports)
     except ArgFormatError:
-        print("Port range specified in wrong format. The correct format is port_start:port_end, e.g. 5001:5003")
+        print("Port range specified in wrong format. The correct format is port_start:port_end, e.g. 5001:5003.")
         exit()
-    
-    
+
     # Creates detector and runs it as thread, listening to image_queue
     try:
         if args.detector == "fps":
@@ -191,27 +191,26 @@ def main(args=None):
         elif args.detector == "opencv":
             from era_5g_object_detection_standalone.worker_face import FaceDetectorWorker as DetectorWorker
         else:
-            print(f"Invalid detector selected. Available options are opencv, mmdetection, fps")
-            
+            raise ImageDetectorInitializationFailed(
+                "Invalid detector selected. Available options are opencv, mmdetection, fps.")
+
         detector_thread = DetectorWorker(logger, "Detector", image_queue, app)
         detector_thread.start(daemon=True)
     except ImageDetectorInitializationFailed as ex:
         print(ex)
         exit()
-    
+
     # Estimate new queue size based on maximum latency
     """avg_latency = latency_measurements.get_avg_latency() # obtained from detector init warmup
     if avg_latency != 0:  # warmup can be skipped
         new_queue_size = int(max_latency / avg_latency)
         image_queue = Queue(new_queue_size)
         detector_thread.input_queue = image_queue"""
-    
-   
+
     # runs the flask server
     # allow_unsafe_werkzeug needs to be true to run inside the docker
     # TODO: use better webserver
-    socketio.run(app, port=5896, host='0.0.0.0', allow_unsafe_werkzeug=True)
-    
+    socketio.run(app, port=5897, host='0.0.0.0', allow_unsafe_werkzeug=True)
 
 
 if __name__ == '__main__':

--- a/src/python/era_5g_object_detection_standalone/requirement.txt
+++ b/src/python/era_5g_object_detection_standalone/requirement.txt
@@ -3,3 +3,4 @@ era_5g_object_detection_common==0.0.1
 flask_socketio==5.3.*
 flask==2.2.*
 flask_session==0.4.*
+simple-websocket


### PR DESCRIPTION
- Převážně formátování části souborů a opravy nějakých překlepů.
- V data_sender_gstreamer_*.py doplněna kontrola otevření videa/streamu a kontrola návratového typu při čtení.
- V test_client_http.py kontrola otevření videa/streamu, kontrola návratového typu při čtení, ukončení vieweru při ukončení nebo chybě programu a ošetření, když není k dispozici obrazovka.
- Globální proměnná gstreamer v interface.py je asi blbost, pak blbne běh současně gstreamer a non-gstreamer klientů - tohle jsem se pokusil upravit.
- Doplnil jsem pár balíčků, které jsem doinstaloval, aby se mi to rozjelo. U některých si nejsem stoprocentně jistý, zda jsou potřeba.
- resource_lock musí být bool ne str
- Opravena adresa pro test s middlewarem
- Zachytávání SIGTERM v gstreamer klient příkladech, kvůli odpojování od NetApp a middlewaru

TODO:

- Pokud se ukončí klient natvrdo (SIGKILL), tak zůstane v interface obsazený port.
- Až skončí video, bylo by asi dobré odregistrovat se.